### PR TITLE
Allow unauthenticated access to contracts page

### DIFF
--- a/app/contracts/page.tsx
+++ b/app/contracts/page.tsx
@@ -1,15 +1,15 @@
 import { auth } from "@/auth"
 import { ContractsDashboard } from "@/components/contracts-dashboard"
 import { getAllDeployments, getUserDeployments } from "@/lib/data/kv"
-import { redirect } from "next/navigation"
 
 export default async function ContractsPage() {
   const session = await auth()
-  if (!session?.user?.id) {
-    redirect("/sign-in?next=/contracts")
-  }
+  const userId = session?.user?.id
 
-  const [userDeployments, allDeployments] = await Promise.all([getUserDeployments(), getAllDeployments()])
+  const [userDeployments, allDeployments] = await Promise.all([
+    userId ? getUserDeployments() : Promise.resolve([]),
+    getAllDeployments(),
+  ])
 
   return <ContractsDashboard userDeployments={userDeployments || []} allDeployments={allDeployments || []} />
 }


### PR DESCRIPTION
## Summary
- allow unauthenticated users to view contracts
- skip fetching user deployments when not logged in

## Testing
- `npx biome check app lib components --reporter summary`

------
https://chatgpt.com/codex/tasks/task_e_68628c7fa0748322b9f55b2a8ad16819